### PR TITLE
Updated sub module links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,21 @@
 [submodule "shared"]
 	path = shared
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_SacramentoTrinity/shared.git
+	url = git@github.com:DOI-BOR/Sacramento-WTMP-Shared.git
 [submodule "rss"]
 	path = rss
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_SacramentoTrinity/rss.git
+	url = git@github.com:DOI-BOR/Sacramento-WTMP-RSS.git
 [submodule "reports"]
 	path = reports
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_SacramentoTrinity/reports.git
+	url = git@github.com:DOI-BOR/Sacramento-WTMP-Reports.git
 [submodule "ras"]
 	path = ras
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_SacramentoTrinity/ras.git
+	url = git@github.com:DOI-BOR/Sacramento-WTMP-RAS.git
 [submodule "cequal-w2"]
 	path = cequal-w2
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_SacramentoTrinity/cequal-w2.git
+	url = git@github.com:DOI-BOR/Sacramento-WTMP-CEQUAL-W2.git
 [submodule "5q"]
 	path = 5q
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_SacramentoTrinity/5q.git
+	url = git@github.com:DOI-BOR/Sacramento-WTMP-5Q.git
 [submodule "scripts"]
 	path = scripts
-	url = https://gitlab.rmanet.app/RMA/usbr-water-quality/wat-studies/wtmp-demo-studies/WTMP_SacramentoTrinity/scripts.git
+	url = git@github.com:DOI-BOR/Sacramento-WTMP-Scripts.git


### PR DESCRIPTION
Previously the submodels were linked the RMA's GitLab. Now they point to the corresponding Reclamation GitHub repositories. The links are the SSH urls.